### PR TITLE
add FileName() method to custom Part struct

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -715,3 +715,11 @@ func (p *Part) newBody() (*Body, error) {
 		Data:        data,
 	}, nil
 }
+
+func (p *Part) FileName() string {
+	if p.contentDispositionParams != nil {
+		return p.contentDispositionParams["filename"]
+	}
+
+	return ""
+}


### PR DESCRIPTION
### Overview

From go 1.17, the source code of *Part.FileName() method has been changed (filename is passed to `filepath.Base(filename)` instead of being returned directly)

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/15611134/200798547-5331ae5a-b3e2-4d08-b4db-c279b3680558.png">

The purpose of the [Base()](https://github.com/golang/go/blob/master/src/path/filepath/path.go#L574) is to only return the file name instead of the entire file path. For example, when you pass "directory/filename.pdf" to filepath.Base, it will only return the `filename.pdf.`. `filepath.Base` method does that by finding the first "/" character in the provided string.

But in Flair, the `filename` in `Content-Disposition` in an attachment file is always the file name, not the file path and the `filename` is UTF8 decoded so it might contain the "/" character. For example: 

<img width="740" alt="image" src="https://user-images.githubusercontent.com/15611134/200802482-54f3c460-b1f5-432d-a39d-6f041748bb58.png">

So if we keep using the default FileName() function in go 1.19, it will returned the wrong value which will make the test fail:
![image](https://user-images.githubusercontent.com/15611134/200802684-a19bb51a-c5f7-44ce-bc40-af752b2db67d.png)


### Changes made in this PR

- Add a FileName() method which will simply return the `filename` in `Content-Disposition` in mail header.

