### PR TITLE
Fix to check attachment before swtich case

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -324,6 +324,14 @@ func parseMultipartMixed(msg io.Reader, boundary string, depth int) (textBody, h
 		} else if err != nil {
 			return textBody, htmlBody, attachments, embeddedFiles, textBodies, htmlBodies, err
 		}
+		if isAttachment(part) {
+			at, err := decodeAttachment(part)
+			if err != nil {
+				return textBody, htmlBody, attachments, embeddedFiles, textBodies, htmlBodies, err
+			}
+			attachments = append(attachments, at)
+			continue
+		}
 		contentType, params := part.contentType, part.contentTypeParams
 		if err != nil {
 			return textBody, htmlBody, attachments, embeddedFiles, textBodies, htmlBodies, err
@@ -403,13 +411,6 @@ func parseMultipartMixed(msg io.Reader, boundary string, depth int) (textBody, h
 					at.Filename = decodeMimeSentence(name)
 				}
 			}
-			attachments = append(attachments, at)
-		} else if isAttachment(part) {
-			at, err := decodeAttachment(part)
-			if err != nil {
-				return textBody, htmlBody, attachments, embeddedFiles, textBodies, htmlBodies, err
-			}
-
 			attachments = append(attachments, at)
 		} else {
 			return textBody, htmlBody, attachments, embeddedFiles, textBodies, htmlBodies, fmt.Errorf("Unknown multipart/mixed nested mime type: %s", contentType)

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -435,6 +435,37 @@ So, "Hello".`,
 				},
 			},
 		},
+		15: {
+			contentType: "multipart/signed; protocol=\"application/pkcs7-signature\"; micalg=sha-256; boundary=\"----=_Part_746216_364383494.1698130589208\"",
+			mailData:    htmlAttachmentExample,
+			subject:     "Saying Hello",
+			from: []mail.Address{
+				{
+					Name:    "John Doe",
+					Address: "jdoe@machine.example",
+				},
+			},
+			sender: mail.Address{
+				Name:    "Michael Jones",
+				Address: "mjones@machine.example",
+			},
+			to: []mail.Address{
+				{
+					Name:    "Mary Smith",
+					Address: "mary@example.net",
+				},
+			},
+			messageID: "1234@local.machine.example",
+			date:      parseDate("Fri, 21 Nov 1997 09:55:06 -0600"),
+			htmlBody:  "PGRpdiBkaXI9Imx0ciI+PGRpdj5UaGlzIGlzIGEgcmVjZWlwdC48L2Rpdj48ZGl2Pjxicj48L2Rp\ndj48ZGl2Pjxicj48YnI+PC9kaXY+PC9kaXY+",
+			attachments: []attachmentData{
+				{
+					filename:    "Receipt.html",
+					contentType: "text/html",
+					data:        "<div dir=\"ltr\"><div>This is a receipt.</div><div><br></div><div><br><br></div></div>",
+				},
+			},
+		},
 	}
 
 	for index, td := range testData {
@@ -1019,5 +1050,36 @@ Content-Disposition: attachment; filename="smime.p7s"
 Content-Description: S/MIME Cryptographic Signature
 
 
+------=_Part_746216_364383494.1698130589208--
+`
+
+var htmlAttachmentExample = `MIME-Version: 1.0
+From: John Doe <jdoe@machine.example>
+Sender: Michael Jones <mjones@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+Subject: ooops
+To: test@example.rocks
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg=sha-256;
+	boundary="----=_Part_746216_364383494.1698130589208"
+X-Comments:
+Feedback-ID: 1.ap-northeast-1.Pw8FL2ZI4Ah4ultEiAJulZI5IJxZ/+eKa4j/3x7HjXU=:AmazonSES
+X-SES-Outgoing: 2023.10.24-23.251.234.52
+
+------=_Part_746216_364383494.1698130589208
+Content-Transfer-Encoding: base64
+Content-Type: text/html; charset=UTF-8
+
+PGRpdiBkaXI9Imx0ciI+PGRpdj5UaGlzIGlzIGEgcmVjZWlwdC48L2Rpdj48ZGl2Pjxicj48L2Rp
+dj48ZGl2Pjxicj48YnI+PC9kaXY+PC9kaXY+
+------=_Part_746216_364383494.1698130589208
+Content-Disposition: attachment; filename="Receipt.html"
+Content-Transfer-Encoding: base64
+Content-Type: text/html; charset=utf-8; name="Receipt.html"
+
+PGRpdiBkaXI9Imx0ciI+PGRpdj5UaGlzIGlzIGEgcmVjZWlwdC48L2Rpdj48ZGl2Pjxicj48L2Rp
+dj48ZGl2Pjxicj48YnI+PC9kaXY+PC9kaXY+
 ------=_Part_746216_364383494.1698130589208--
 `


### PR DESCRIPTION
## Outline
Currently, even if the part is attachment, it’s appended to the html bodies array.
This change gives us ability to extract attachments with mime-type of text/html as well

## changes
- Moved the process to check attachment
- Added test

## Reference
```
https://github.com/DusanKasan/parsemail/pull/41
```

## UT
<img width="1688" alt="parsemail_–_parsemail_test_go" src="https://github.com/yamadatakuji-mfw/parsemail/assets/82353726/90f4cb60-4cdc-4d37-9326-c368d043fec3">
